### PR TITLE
Create next beta

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,7 +47,7 @@ jobs:
           
           if [[ "${{ github.event.inputs.prerelease }}" == "true" ]]; then
             prereleases=$(gh release list --limit 1000 --json tagName,isPrerelease -q '.[] | select(.isPrerelease==true) | .tagName' || true)
-            last_beta=$(echo "$prereleases" | grep "^${NEXT}-Beta" | sort -V | tail -n1 | sed -E 's/.*-Beta([0-9]+)/\1/' || true)
+            last_beta=$(echo "$prereleases" | grep "^${NEXT}-Beta" | sort -V | tail -n1 | sed -E 's/.*-Beta([0-9]+)/\1/' || echo '0')
             last_beta=${last_beta:-0}
             next_beta=$(printf "%02d" $((10#$last_beta + 1)))
             NEXT="${NEXT}-Beta${next_beta}"


### PR DESCRIPTION
This pull request makes a small improvement to the prerelease version calculation logic in the GitHub Actions workflow. The change ensures that the `last_beta` variable is always set to a valid value, even if no previous beta releases are found.

* Improved error handling and default value assignment for the `last_beta` variable in `.github/workflows/build-release.yml`, ensuring it defaults to `0` if no previous beta release is found.