### PR TITLE
Improve error message for long video descriptions

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/malv/descuentados/services/YoutubeService.kt
+++ b/composeApp/src/jvmMain/kotlin/org/malv/descuentados/services/YoutubeService.kt
@@ -118,7 +118,7 @@ class YoutubeService(
 
         val newDescription = video.description.replace(codes, newCodes)
         if (newDescription.length > MAX_LENGTH) {
-            return VideoResult(video.id, video.title, VideoStatus.ERROR, "Descripción demasiado larga.")
+            return VideoResult(video.id, video.title, VideoStatus.ERROR, "Descripción demasiado larga: ${video.description.length} -> ${newDescription.length}")
         }
 
         return runCatching {


### PR DESCRIPTION
The pull request enhances the error message displayed when a video description exceeds the maximum length, making it more user-friendly and descriptive.